### PR TITLE
Select sensor config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -7,6 +7,7 @@ config DRV2605
   bool "DRV2605 haptic motor driver"
   default $(dt_compat_enabled,$(DT_COMPAT_DRV2605))
   select I2C
+  select SENSOR
   help
       Enable DRV2605 haptic motor driver.
 


### PR DESCRIPTION
Just a little fix to select sensor api manually. It's not selected automatically when you disable ble/usb (eg for power profiling).